### PR TITLE
Add Datahub datasets various changes

### DIFF
--- a/src/main/java/org/aksw/gerbil/bat/datasets/FileBasedNIFDataset.java
+++ b/src/main/java/org/aksw/gerbil/bat/datasets/FileBasedNIFDataset.java
@@ -30,6 +30,7 @@ public class FileBasedNIFDataset extends AbstractNIFDataset {
     protected InputStream getDataAsInputStream() {
         FileInputStream fin = null;
         try {
+            LOGGER.debug("LOAD FROM {}", filePath);
             fin = new FileInputStream(filePath);
         } catch (FileNotFoundException e) {
             LOGGER.error("Couldn't load NIF dataset from file.", e);

--- a/src/main/java/org/aksw/gerbil/datasets/DatahubNIFConfig.java
+++ b/src/main/java/org/aksw/gerbil/datasets/DatahubNIFConfig.java
@@ -1,0 +1,55 @@
+package org.aksw.gerbil.datasets;
+
+import it.acubelab.batframework.problems.TopicDataset;
+import it.acubelab.batframework.systemPlugins.DBPediaApi;
+import it.acubelab.batframework.utils.WikipediaApiInterface;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+import org.aksw.gerbil.bat.datasets.FileBasedNIFDataset;
+import org.aksw.gerbil.config.GerbilConfiguration;
+import org.aksw.gerbil.datatypes.ExperimentType;
+import org.apache.jena.riot.Lang;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestTemplate;
+
+public class DatahubNIFConfig extends AbstractDatasetConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatahubNIFConfig.class);
+    private static final String NIF_DATASET_FILE_PROPERTY_NAME = "org.aksw.gerbil.datasets.Datahub";
+    private DBPediaApi dbpediaApi;
+    private WikipediaApiInterface wikiApi;
+    private String datasetUrl;
+
+    private RestTemplate rt;
+
+    public DatahubNIFConfig(WikipediaApiInterface wikiApi, DBPediaApi dbpediaApi, String datasetName,
+            String datasetUrl, boolean couldBeCached) {
+        super(datasetName, couldBeCached, ExperimentType.Sa2W);
+        this.wikiApi = wikiApi;
+        this.dbpediaApi = dbpediaApi;
+        this.datasetUrl = datasetUrl;
+        rt = new RestTemplate();
+    }
+
+    @Override
+    protected TopicDataset loadDataset() throws Exception {
+        String nifFile = GerbilConfiguration.getInstance().getString(NIF_DATASET_FILE_PROPERTY_NAME) + datasetName;
+        logger.debug("FILE {}", nifFile);
+        File f = new File(nifFile);
+        if (!f.exists()) {
+            logger.debug("file {} does not exists. need to download", nifFile);
+            String data = rt.getForObject(datasetUrl, String.class);
+
+            Path file = Files.createFile(Paths.get(nifFile));
+            Files.write(file, data.getBytes(), StandardOpenOption.WRITE);
+        }
+
+        return new FileBasedNIFDataset(wikiApi, dbpediaApi, nifFile, getDatasetName(), Lang.TTL);
+    }
+}

--- a/src/main/java/org/aksw/gerbil/datasets/datahub/DatahubNIFLoader.java
+++ b/src/main/java/org/aksw/gerbil/datasets/datahub/DatahubNIFLoader.java
@@ -1,0 +1,94 @@
+package org.aksw.gerbil.datasets.datahub;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.annotation.PostConstruct;
+
+import org.aksw.gerbil.datasets.datahub.model.Dataset;
+import org.aksw.gerbil.datasets.datahub.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+public class DatahubNIFLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatahubNIFLoader.class);
+
+    // TODO - add to application.properties
+    private static final String NIF_TAGGED_CORPURA_URL = "http://datahub.io/api/1/rest/tag/nif";
+    private static final String NIF_CORPUS_META_INF_URL = "http://datahub.io/api/3/action/package_show?id=";
+    private RestTemplate rt;
+    private Map<String, String> datasets;
+
+    public DatahubNIFLoader() {
+        rt = new RestTemplate();
+        init();
+    }
+
+    private void init() {
+        List<String> nifDataSets = getNIFDataSets();
+        getNIFDataSetsMetaInformation(nifDataSets);
+    }
+
+    private void getNIFDataSetsMetaInformation(List<String> nifDataSets) {
+        datasets = Maps.newHashMap();
+        // go through all datasets tagged with nif
+        for (String d : nifDataSets) {
+            ResponseEntity<Dataset.Response> entity = rt.getForEntity(NIF_CORPUS_META_INF_URL + d,
+                    Dataset.Response.class);
+            if (entity.getStatusCode().equals(HttpStatus.OK)) {
+                Dataset.Response body = entity.getBody();
+                List<Resource> resources = body.getResult().getResources();
+                // go through the downloadable Resources
+                for (Resource r : resources) {
+                    String url = r.getUrl();
+                    logger.debug("checking {}", url);
+                    HttpHeaders headers = rt.headForHeaders(url);
+                    long contentLength = headers.getContentLength();
+                    logger.debug("{} bytes", contentLength);
+                    // FIXME - put the magic number in application.properties
+                    // add if less than 20mb ends with ttl (turtle) but not with dataid.ttl (we aint gonna need it yet)
+                    if (contentLength < 20_000_000 && url.endsWith(".ttl") && !url.endsWith("dataid.ttl")) {
+                        logger.debug("{}: {} has less than 20mb and is turtle > add to Dataset", d, url);
+                        datasets.put(d, url);
+                    }
+                }
+            }
+        }
+
+    }
+
+    private List<String> getNIFDataSets() {
+        List<String> result = Lists.newArrayList();
+        ResponseEntity<String[]> forEntity = rt.getForEntity(NIF_TAGGED_CORPURA_URL, String[].class);
+        if (forEntity.getStatusCode().equals(HttpStatus.OK)) {
+            logger.debug("everything is ok");
+            String[] body = forEntity.getBody();
+            result = Lists.newArrayList(body);
+            logger.debug("corpura {}", datasets);
+        }
+        return result;
+    }
+
+    public static void main(String[] args) {
+        DatahubNIFLoader d = new DatahubNIFLoader();
+        d.init();
+
+        for (Entry<String, String> e : d.datasets.entrySet()) {
+            logger.debug("{}: {}", e.getKey(), e.getValue());
+        }
+    }
+
+    public Map<String, String> getDataSets() {
+        return datasets;
+    }
+}

--- a/src/main/java/org/aksw/gerbil/datasets/datahub/model/Dataset.java
+++ b/src/main/java/org/aksw/gerbil/datasets/datahub/model/Dataset.java
@@ -1,0 +1,684 @@
+package org.aksw.gerbil.datasets.datahub.model;
+
+import java.util.Date;
+import java.util.List;
+
+import org.aksw.gerbil.datasets.datahub.model.Resource.TrackingSummary;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * Represents a CKAN Dataset (previously a Package)
+ * 
+ * @author Ross Jones <ross.jones@okfn.org>
+ * @version 1.7
+ * @since 2012-05-01
+ */
+public class Dataset {
+
+    public static class Response {
+        private String help;
+
+        private Error error;
+
+        private boolean success;
+
+        private Dataset result;
+
+        public String getHelp() {
+            return help;
+        }
+
+        public void setHelp(String help) {
+            this.help = help;
+        }
+
+        public Error getError() {
+            return error;
+        }
+
+        public void setError(Error error) {
+            this.error = error;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public void setSuccess(boolean success) {
+            this.success = success;
+        }
+
+        public Dataset getResult() {
+            return result;
+        }
+
+        public void setResult(Dataset result) {
+            this.result = result;
+        }
+    }
+
+    private String author;
+
+    private String author_email;
+
+    private String creator_user_id;
+
+    private List<Extra> extras;
+
+    private List<Group> groups;
+
+    private String id;
+
+    private Boolean isopen;
+
+    private String license_id;
+
+    private String license_title;
+
+    private String license_url;
+
+    private String maintainer;
+
+    private String maintainer_email;
+
+    private Date metadata_created;
+
+    private Date metadata_modified;
+
+    private String name;
+
+    private String notes;
+
+    private Long num_resources;
+
+    private Long num_tags;
+
+    private Organization organization;
+
+    private String owner_org;
+
+    @JsonProperty("private")
+    private Boolean _private;
+
+    private List<Object> relationships_as_object;
+
+    private List<Object> relationships_as_subject;
+
+    private List<Resource> resources;
+
+    private String revision_id;
+
+    private Date revision_timestamp;
+
+    private String state;
+
+    private List<Tag> tags;
+
+    private String title;
+
+    private TrackingSummary tracking_summary;
+
+    private String type;
+
+    private String url;
+
+    private String version;
+
+    public Dataset() {
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getAuthor_email() {
+        return author_email;
+    }
+
+    public void setAuthor_email(String author_email) {
+        this.author_email = author_email;
+    }
+
+    public String getCreator_user_id() {
+        return creator_user_id;
+    }
+
+    public void setCreator_user_id(String creator_user_id) {
+        this.creator_user_id = creator_user_id;
+    }
+
+    public List<Extra> getExtras() {
+        return extras;
+    }
+
+    public void setExtras(List<Extra> extras) {
+        this.extras = extras;
+    }
+
+    public List<Group> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<Group> groups) {
+        this.groups = groups;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Boolean getIsopen() {
+        return isopen;
+    }
+
+    public void setIsopen(Boolean isopen) {
+        this.isopen = isopen;
+    }
+
+    public String getLicense_id() {
+        return license_id;
+    }
+
+    public void setLicense_id(String license_id) {
+        this.license_id = license_id;
+    }
+
+    public String getLicense_title() {
+        return license_title;
+    }
+
+    public void setLicense_title(String license_title) {
+        this.license_title = license_title;
+    }
+
+    public String getLicense_url() {
+        return license_url;
+    }
+
+    public void setLicense_url(String license_url) {
+        this.license_url = license_url;
+    }
+
+    public String getMaintainer() {
+        return maintainer;
+    }
+
+    public void setMaintainer(String maintainer) {
+        this.maintainer = maintainer;
+    }
+
+    public String getMaintainer_email() {
+        return maintainer_email;
+    }
+
+    public void setMaintainer_email(String maintainer_email) {
+        this.maintainer_email = maintainer_email;
+    }
+
+    public Date getMetadata_created() {
+        return metadata_created;
+    }
+
+    public void setMetadata_created(Date metadata_created) {
+        this.metadata_created = metadata_created;
+    }
+
+    public Date getMetadata_modified() {
+        return metadata_modified;
+    }
+
+    public void setMetadata_modified(Date metadata_modified) {
+        this.metadata_modified = metadata_modified;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    public Long getNum_resources() {
+        return num_resources;
+    }
+
+    public void setNum_resources(Long num_resources) {
+        this.num_resources = num_resources;
+    }
+
+    public Long getNum_tags() {
+        return num_tags;
+    }
+
+    public void setNum_tags(Long num_tags) {
+        this.num_tags = num_tags;
+    }
+
+    public Organization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(Organization organization) {
+        this.organization = organization;
+    }
+
+    public String getOwner_org() {
+        return owner_org;
+    }
+
+    public void setOwner_org(String owner_org) {
+        this.owner_org = owner_org;
+    }
+
+    public Boolean get_private() {
+        return _private;
+    }
+
+    public void set_private(Boolean _private) {
+        this._private = _private;
+    }
+
+    public List<Object> getRelationships_as_object() {
+        return relationships_as_object;
+    }
+
+    public void setRelationships_as_object(List<Object> relationships_as_object) {
+        this.relationships_as_object = relationships_as_object;
+    }
+
+    public List<Object> getRelationships_as_subject() {
+        return relationships_as_subject;
+    }
+
+    public void setRelationships_as_subject(List<Object> relationships_as_subject) {
+        this.relationships_as_subject = relationships_as_subject;
+    }
+
+    public List<Resource> getResources() {
+        return resources;
+    }
+
+    public void setResources(List<Resource> resources) {
+        this.resources = resources;
+    }
+
+    public String getRevision_id() {
+        return revision_id;
+    }
+
+    public void setRevision_id(String revision_id) {
+        this.revision_id = revision_id;
+    }
+
+    public Date getRevision_timestamp() {
+        return revision_timestamp;
+    }
+
+    public void setRevision_timestamp(Date revision_timestamp) {
+        this.revision_timestamp = revision_timestamp;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public TrackingSummary getTracking_summary() {
+        return tracking_summary;
+    }
+
+    public void setTracking_summary(TrackingSummary tracking_summary) {
+        this.tracking_summary = tracking_summary;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((_private == null) ? 0 : _private.hashCode());
+        result = prime * result + ((author == null) ? 0 : author.hashCode());
+        result = prime * result + ((author_email == null) ? 0 : author_email.hashCode());
+        result = prime * result + ((creator_user_id == null) ? 0 : creator_user_id.hashCode());
+        result = prime * result + ((extras == null) ? 0 : extras.hashCode());
+        result = prime * result + ((groups == null) ? 0 : groups.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((isopen == null) ? 0 : isopen.hashCode());
+        result = prime * result + ((license_id == null) ? 0 : license_id.hashCode());
+        result = prime * result + ((license_title == null) ? 0 : license_title.hashCode());
+        result = prime * result + ((license_url == null) ? 0 : license_url.hashCode());
+        result = prime * result + ((maintainer == null) ? 0 : maintainer.hashCode());
+        result = prime * result + ((maintainer_email == null) ? 0 : maintainer_email.hashCode());
+        result = prime * result + ((metadata_created == null) ? 0 : metadata_created.hashCode());
+        result = prime * result + ((metadata_modified == null) ? 0 : metadata_modified.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((notes == null) ? 0 : notes.hashCode());
+        result = prime * result + ((num_resources == null) ? 0 : num_resources.hashCode());
+        result = prime * result + ((num_tags == null) ? 0 : num_tags.hashCode());
+        result = prime * result + ((organization == null) ? 0 : organization.hashCode());
+        result = prime * result + ((owner_org == null) ? 0 : owner_org.hashCode());
+        result = prime * result + ((relationships_as_object == null) ? 0 : relationships_as_object.hashCode());
+        result = prime * result + ((relationships_as_subject == null) ? 0 : relationships_as_subject.hashCode());
+        result = prime * result + ((resources == null) ? 0 : resources.hashCode());
+        result = prime * result + ((revision_id == null) ? 0 : revision_id.hashCode());
+        result = prime * result + ((revision_timestamp == null) ? 0 : revision_timestamp.hashCode());
+        result = prime * result + ((state == null) ? 0 : state.hashCode());
+        result = prime * result + ((tags == null) ? 0 : tags.hashCode());
+        result = prime * result + ((title == null) ? 0 : title.hashCode());
+        result = prime * result + ((tracking_summary == null) ? 0 : tracking_summary.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((url == null) ? 0 : url.hashCode());
+        result = prime * result + ((version == null) ? 0 : version.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Dataset other = (Dataset) obj;
+        if (_private == null) {
+            if (other._private != null)
+                return false;
+        } else if (!_private.equals(other._private))
+            return false;
+        if (author == null) {
+            if (other.author != null)
+                return false;
+        } else if (!author.equals(other.author))
+            return false;
+        if (author_email == null) {
+            if (other.author_email != null)
+                return false;
+        } else if (!author_email.equals(other.author_email))
+            return false;
+        if (creator_user_id == null) {
+            if (other.creator_user_id != null)
+                return false;
+        } else if (!creator_user_id.equals(other.creator_user_id))
+            return false;
+        if (extras == null) {
+            if (other.extras != null)
+                return false;
+        } else if (!extras.equals(other.extras))
+            return false;
+        if (groups == null) {
+            if (other.groups != null)
+                return false;
+        } else if (!groups.equals(other.groups))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (isopen == null) {
+            if (other.isopen != null)
+                return false;
+        } else if (!isopen.equals(other.isopen))
+            return false;
+        if (license_id == null) {
+            if (other.license_id != null)
+                return false;
+        } else if (!license_id.equals(other.license_id))
+            return false;
+        if (license_title == null) {
+            if (other.license_title != null)
+                return false;
+        } else if (!license_title.equals(other.license_title))
+            return false;
+        if (license_url == null) {
+            if (other.license_url != null)
+                return false;
+        } else if (!license_url.equals(other.license_url))
+            return false;
+        if (maintainer == null) {
+            if (other.maintainer != null)
+                return false;
+        } else if (!maintainer.equals(other.maintainer))
+            return false;
+        if (maintainer_email == null) {
+            if (other.maintainer_email != null)
+                return false;
+        } else if (!maintainer_email.equals(other.maintainer_email))
+            return false;
+        if (metadata_created == null) {
+            if (other.metadata_created != null)
+                return false;
+        } else if (!metadata_created.equals(other.metadata_created))
+            return false;
+        if (metadata_modified == null) {
+            if (other.metadata_modified != null)
+                return false;
+        } else if (!metadata_modified.equals(other.metadata_modified))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (notes == null) {
+            if (other.notes != null)
+                return false;
+        } else if (!notes.equals(other.notes))
+            return false;
+        if (num_resources == null) {
+            if (other.num_resources != null)
+                return false;
+        } else if (!num_resources.equals(other.num_resources))
+            return false;
+        if (num_tags == null) {
+            if (other.num_tags != null)
+                return false;
+        } else if (!num_tags.equals(other.num_tags))
+            return false;
+        if (organization == null) {
+            if (other.organization != null)
+                return false;
+        } else if (!organization.equals(other.organization))
+            return false;
+        if (owner_org == null) {
+            if (other.owner_org != null)
+                return false;
+        } else if (!owner_org.equals(other.owner_org))
+            return false;
+        if (relationships_as_object == null) {
+            if (other.relationships_as_object != null)
+                return false;
+        } else if (!relationships_as_object.equals(other.relationships_as_object))
+            return false;
+        if (relationships_as_subject == null) {
+            if (other.relationships_as_subject != null)
+                return false;
+        } else if (!relationships_as_subject.equals(other.relationships_as_subject))
+            return false;
+        if (resources == null) {
+            if (other.resources != null)
+                return false;
+        } else if (!resources.equals(other.resources))
+            return false;
+        if (revision_id == null) {
+            if (other.revision_id != null)
+                return false;
+        } else if (!revision_id.equals(other.revision_id))
+            return false;
+        if (revision_timestamp == null) {
+            if (other.revision_timestamp != null)
+                return false;
+        } else if (!revision_timestamp.equals(other.revision_timestamp))
+            return false;
+        if (state == null) {
+            if (other.state != null)
+                return false;
+        } else if (!state.equals(other.state))
+            return false;
+        if (tags == null) {
+            if (other.tags != null)
+                return false;
+        } else if (!tags.equals(other.tags))
+            return false;
+        if (title == null) {
+            if (other.title != null)
+                return false;
+        } else if (!title.equals(other.title))
+            return false;
+        if (tracking_summary == null) {
+            if (other.tracking_summary != null)
+                return false;
+        } else if (!tracking_summary.equals(other.tracking_summary))
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        if (url == null) {
+            if (other.url != null)
+                return false;
+        } else if (!url.equals(other.url))
+            return false;
+        if (version == null) {
+            if (other.version != null)
+                return false;
+        } else if (!version.equals(other.version))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Dataset [author=");
+        builder.append(author);
+        builder.append(", author_email=");
+        builder.append(author_email);
+        builder.append(", creator_user_id=");
+        builder.append(creator_user_id);
+        builder.append(", extras=");
+        builder.append(extras);
+        builder.append(", groups=");
+        builder.append(groups);
+        builder.append(", id=");
+        builder.append(id);
+        builder.append(", isopen=");
+        builder.append(isopen);
+        builder.append(", license_id=");
+        builder.append(license_id);
+        builder.append(", license_title=");
+        builder.append(license_title);
+        builder.append(", license_url=");
+        builder.append(license_url);
+        builder.append(", maintainer=");
+        builder.append(maintainer);
+        builder.append(", maintainer_email=");
+        builder.append(maintainer_email);
+        builder.append(", metadata_created=");
+        builder.append(metadata_created);
+        builder.append(", metadata_modified=");
+        builder.append(metadata_modified);
+        builder.append(", name=");
+        builder.append(name);
+        builder.append(", notes=");
+        builder.append(notes);
+        builder.append(", num_resources=");
+        builder.append(num_resources);
+        builder.append(", num_tags=");
+        builder.append(num_tags);
+        builder.append(", organization=");
+        builder.append(organization);
+        builder.append(", owner_org=");
+        builder.append(owner_org);
+        builder.append(", _private=");
+        builder.append(_private);
+        builder.append(", relationships_as_object=");
+        builder.append(relationships_as_object);
+        builder.append(", relationships_as_subject=");
+        builder.append(relationships_as_subject);
+        builder.append(", resources=");
+        builder.append(resources);
+        builder.append(", revision_id=");
+        builder.append(revision_id);
+        builder.append(", revision_timestamp=");
+        builder.append(revision_timestamp);
+        builder.append(", state=");
+        builder.append(state);
+        builder.append(", tags=");
+        builder.append(tags);
+        builder.append(", title=");
+        builder.append(title);
+        builder.append(", tracking_summary=");
+        builder.append(tracking_summary);
+        builder.append(", type=");
+        builder.append(type);
+        builder.append(", url=");
+        builder.append(url);
+        builder.append(", version=");
+        builder.append(version);
+        builder.append("]");
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/org/aksw/gerbil/datasets/datahub/model/Extra.java
+++ b/src/main/java/org/aksw/gerbil/datasets/datahub/model/Extra.java
@@ -1,0 +1,163 @@
+package org.aksw.gerbil.datasets.datahub.model;
+
+/**
+ * Represents an extra metadata field in a dataset or group
+ * 
+ * @author Ross Jones <ross.jones@okfn.org>
+ * @version 1.7
+ * @since 2012-05-01
+ */
+public class Extra {
+
+    private String key;
+
+    private String value;
+
+    private Extras __extras;
+
+    public class Extras {
+        private String package_id;
+        private String revision_id;
+
+        public String getPackage_id() {
+            return package_id;
+        }
+
+        public void setPackage_id(String package_id) {
+            this.package_id = package_id;
+        }
+
+        public String getRevision_id() {
+            return revision_id;
+        }
+
+        public void setRevision_id(String revision_id) {
+            this.revision_id = revision_id;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getOuterType().hashCode();
+            result = prime * result + ((package_id == null) ? 0 : package_id.hashCode());
+            result = prime * result + ((revision_id == null) ? 0 : revision_id.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Extras other = (Extras) obj;
+            if (!getOuterType().equals(other.getOuterType()))
+                return false;
+            if (package_id == null) {
+                if (other.package_id != null)
+                    return false;
+            } else if (!package_id.equals(other.package_id))
+                return false;
+            if (revision_id == null) {
+                if (other.revision_id != null)
+                    return false;
+            } else if (!revision_id.equals(other.revision_id))
+                return false;
+            return true;
+        }
+
+        private Extra getOuterType() {
+            return Extra.this;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append("Extras [package_id=");
+            builder.append(package_id);
+            builder.append(", revision_id=");
+            builder.append(revision_id);
+            builder.append("]");
+            return builder.toString();
+        }
+
+    }
+
+    public Extra() {
+    }
+
+    public Extra(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Extra other = (Extra) obj;
+        if (key == null) {
+            if (other.key != null)
+                return false;
+        } else if (!key.equals(other.key))
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Extra [key=");
+        builder.append(key);
+        builder.append(", value=");
+        builder.append(value);
+        builder.append("]");
+        return builder.toString();
+    }
+
+    public Extras get__extras() {
+        return __extras;
+    }
+
+    public void set__extras(Extras __extras) {
+        this.__extras = __extras;
+    }
+
+}

--- a/src/main/java/org/aksw/gerbil/datasets/datahub/model/Group.java
+++ b/src/main/java/org/aksw/gerbil/datasets/datahub/model/Group.java
@@ -1,0 +1,159 @@
+package org.aksw.gerbil.datasets.datahub.model;
+
+/**
+ * Represents a CKAN group
+ * 
+ * @author Ross Jones <ross.jones@okfn.org>
+ * @version 1.7
+ * @since 2012-05-01
+ */
+public class Group {
+
+    private String description;
+
+    private String display_name;
+
+    private String id;
+
+    private String image_display_url;
+
+    private String name;
+
+    private String title;
+
+    public Group() {
+    }
+
+    public Group(String description, String display_name, String id, String image_display_url, String name, String title) {
+        super();
+        this.description = description;
+        this.display_name = display_name;
+        this.id = id;
+        this.image_display_url = image_display_url;
+        this.name = name;
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDisplay_name() {
+        return display_name;
+    }
+
+    public void setDisplay_name(String display_name) {
+        this.display_name = display_name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getImage_display_url() {
+        return image_display_url;
+    }
+
+    public void setImage_display_url(String image_display_url) {
+        this.image_display_url = image_display_url;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((display_name == null) ? 0 : display_name.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((image_display_url == null) ? 0 : image_display_url.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((title == null) ? 0 : title.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Group other = (Group) obj;
+        if (description == null) {
+            if (other.description != null)
+                return false;
+        } else if (!description.equals(other.description))
+            return false;
+        if (display_name == null) {
+            if (other.display_name != null)
+                return false;
+        } else if (!display_name.equals(other.display_name))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (image_display_url == null) {
+            if (other.image_display_url != null)
+                return false;
+        } else if (!image_display_url.equals(other.image_display_url))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (title == null) {
+            if (other.title != null)
+                return false;
+        } else if (!title.equals(other.title))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Group [description=");
+        builder.append(description);
+        builder.append(", display_name=");
+        builder.append(display_name);
+        builder.append(", id=");
+        builder.append(id);
+        builder.append(", image_display_url=");
+        builder.append(image_display_url);
+        builder.append(", name=");
+        builder.append(name);
+        builder.append(", title=");
+        builder.append(title);
+        builder.append("]");
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/org/aksw/gerbil/datasets/datahub/model/Organization.java
+++ b/src/main/java/org/aksw/gerbil/datasets/datahub/model/Organization.java
@@ -1,0 +1,269 @@
+package org.aksw.gerbil.datasets.datahub.model;
+
+import java.util.Date;
+
+public class Organization {
+    private String approval_status;
+
+    private Date created;
+
+    private String description;
+
+    private String id;
+
+    private String image_url;
+
+    private Boolean is_organization;
+
+    private String name;
+
+    private String revision_id;
+
+    private Date revision_timestamp;
+
+    private String state;
+
+    private String Title;
+
+    private String type;
+
+    public Organization() {
+    }
+
+    public Organization(String approval_status, Date created, String description, String id, String image_url,
+            Boolean is_organization, String name, String revision_id, Date revision_timestamp, String state,
+            String title, String type) {
+        super();
+        this.approval_status = approval_status;
+        this.created = created;
+        this.description = description;
+        this.id = id;
+        this.image_url = image_url;
+        this.is_organization = is_organization;
+        this.name = name;
+        this.revision_id = revision_id;
+        this.revision_timestamp = revision_timestamp;
+        this.state = state;
+        Title = title;
+        this.type = type;
+    }
+
+    public String getApproval_status() {
+        return approval_status;
+    }
+
+    public void setApproval_status(String approval_status) {
+        this.approval_status = approval_status;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getImage_url() {
+        return image_url;
+    }
+
+    public void setImage_url(String image_url) {
+        this.image_url = image_url;
+    }
+
+    public Boolean getIs_organization() {
+        return is_organization;
+    }
+
+    public void setIs_organization(Boolean is_organization) {
+        this.is_organization = is_organization;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getRevision_id() {
+        return revision_id;
+    }
+
+    public void setRevision_id(String revision_id) {
+        this.revision_id = revision_id;
+    }
+
+    public Date getRevision_timestamp() {
+        return revision_timestamp;
+    }
+
+    public void setRevision_timestamp(Date revision_timestamp) {
+        this.revision_timestamp = revision_timestamp;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getTitle() {
+        return Title;
+    }
+
+    public void setTitle(String title) {
+        Title = title;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((Title == null) ? 0 : Title.hashCode());
+        result = prime * result + ((approval_status == null) ? 0 : approval_status.hashCode());
+        result = prime * result + ((created == null) ? 0 : created.hashCode());
+        result = prime * result + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((image_url == null) ? 0 : image_url.hashCode());
+        result = prime * result + ((is_organization == null) ? 0 : is_organization.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((revision_id == null) ? 0 : revision_id.hashCode());
+        result = prime * result + ((revision_timestamp == null) ? 0 : revision_timestamp.hashCode());
+        result = prime * result + ((state == null) ? 0 : state.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Organization other = (Organization) obj;
+        if (Title == null) {
+            if (other.Title != null)
+                return false;
+        } else if (!Title.equals(other.Title))
+            return false;
+        if (approval_status == null) {
+            if (other.approval_status != null)
+                return false;
+        } else if (!approval_status.equals(other.approval_status))
+            return false;
+        if (created == null) {
+            if (other.created != null)
+                return false;
+        } else if (!created.equals(other.created))
+            return false;
+        if (description == null) {
+            if (other.description != null)
+                return false;
+        } else if (!description.equals(other.description))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (image_url == null) {
+            if (other.image_url != null)
+                return false;
+        } else if (!image_url.equals(other.image_url))
+            return false;
+        if (is_organization == null) {
+            if (other.is_organization != null)
+                return false;
+        } else if (!is_organization.equals(other.is_organization))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (revision_id == null) {
+            if (other.revision_id != null)
+                return false;
+        } else if (!revision_id.equals(other.revision_id))
+            return false;
+        if (revision_timestamp == null) {
+            if (other.revision_timestamp != null)
+                return false;
+        } else if (!revision_timestamp.equals(other.revision_timestamp))
+            return false;
+        if (state == null) {
+            if (other.state != null)
+                return false;
+        } else if (!state.equals(other.state))
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Organization [approval_status=");
+        builder.append(approval_status);
+        builder.append(", created=");
+        builder.append(created);
+        builder.append(", description=");
+        builder.append(description);
+        builder.append(", id=");
+        builder.append(id);
+        builder.append(", image_url=");
+        builder.append(image_url);
+        builder.append(", is_organization=");
+        builder.append(is_organization);
+        builder.append(", name=");
+        builder.append(name);
+        builder.append(", revision_id=");
+        builder.append(revision_id);
+        builder.append(", revision_timestamp=");
+        builder.append(revision_timestamp);
+        builder.append(", state=");
+        builder.append(state);
+        builder.append(", Title=");
+        builder.append(Title);
+        builder.append(", type=");
+        builder.append(type);
+        builder.append("]");
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/org/aksw/gerbil/datasets/datahub/model/Resource.java
+++ b/src/main/java/org/aksw/gerbil/datasets/datahub/model/Resource.java
@@ -1,0 +1,555 @@
+package org.aksw.gerbil.datasets.datahub.model;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+/**
+ * Represents a single resource within a Dataset
+ * 
+ * @author Ross Jones <ross.jones@okfn.org>
+ * @version 2.2
+ * @since 2012-05-01
+ */
+public class Resource {
+    public static class Response {
+        private String help;
+
+        private Error error;
+
+        private boolean success;
+
+        private Resource result;
+
+        public Response() {
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public void setSuccess(boolean success) {
+            this.success = success;
+        }
+
+        public Resource getResult() {
+            return result;
+        }
+
+        public void setResult(Resource result) {
+            this.result = result;
+        }
+
+        public Error getError() {
+            return error;
+        }
+
+        public void setError(Error error) {
+            this.error = error;
+        }
+
+        public String getHelp() {
+            return help;
+        }
+
+        public void setHelp(String help) {
+            this.help = help;
+        }
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this);
+        }
+    }
+
+    public static class TrackingSummary {
+        private long recent;
+
+        private long total;
+
+        public TrackingSummary() {
+        }
+
+        public long getRecent() {
+            return recent;
+        }
+
+        public void setRecent(long recent) {
+            this.recent = recent;
+        }
+
+        public long getTotal() {
+            return total;
+        }
+
+        public void setTotal(long total) {
+            this.total = total;
+        }
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this);
+        }
+    }
+
+    private String cache_last_updated;
+
+    private String cache_url;
+
+    private String created;
+
+    private String description;
+
+    private String format;
+
+    private String hash;
+
+    private String id;
+
+    private String last_modified;
+
+    private String mimetype;
+
+    private String mimetype_inner;
+
+    private String name;
+
+    // only on create
+    private String package_id;
+
+    // generated
+    private long position;
+
+    // generated
+    private String resource_group_id;
+
+    private String resource_type;
+
+    private String revision_id;
+
+    // generated
+    private String revision_timestamp;
+
+    private long size;
+
+    // generated
+    private String state;
+
+    // generated
+    private TrackingSummary tracking_summary;
+
+    private String url;
+
+    // generated
+    private String url_type;
+
+    private String webstore_last_updated;
+
+    private String webstore_url;
+
+    public Resource() {
+    }
+
+    public String getCache_last_updated() {
+        return cache_last_updated;
+    }
+
+    public void setCache_last_updated(String cache_last_updated) {
+        this.cache_last_updated = cache_last_updated;
+    }
+
+    public String getCache_url() {
+        return cache_url;
+    }
+
+    public void setCache_url(String cache_url) {
+        this.cache_url = cache_url;
+    }
+
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getLast_modified() {
+        return last_modified;
+    }
+
+    public void setLast_modified(String last_modified) {
+        this.last_modified = last_modified;
+    }
+
+    public String getMimetype() {
+        return mimetype;
+    }
+
+    public void setMimetype(String mimetype) {
+        this.mimetype = mimetype;
+    }
+
+    public String getMimetype_inner() {
+        return mimetype_inner;
+    }
+
+    public void setMimetype_inner(String mimetype_inner) {
+        this.mimetype_inner = mimetype_inner;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPackage_id() {
+        return package_id;
+    }
+
+    public void setPackage_id(String package_id) {
+        this.package_id = package_id;
+    }
+
+    public long getPosition() {
+        return position;
+    }
+
+    public void setPosition(long position) {
+        this.position = position;
+    }
+
+    public String getResource_group_id() {
+        return resource_group_id;
+    }
+
+    public void setResource_group_id(String resource_group_id) {
+        this.resource_group_id = resource_group_id;
+    }
+
+    public String getResource_type() {
+        return resource_type;
+    }
+
+    public void setResource_type(String resource_type) {
+        this.resource_type = resource_type;
+    }
+
+    public String getRevision_id() {
+        return revision_id;
+    }
+
+    public void setRevision_id(String revision_id) {
+        this.revision_id = revision_id;
+    }
+
+    public String getRevision_timestamp() {
+        return revision_timestamp;
+    }
+
+    public void setRevision_timestamp(String revision_timestamp) {
+        this.revision_timestamp = revision_timestamp;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public TrackingSummary getTracking_summary() {
+        return tracking_summary;
+    }
+
+    public void setTracking_summary(TrackingSummary tracking_summary) {
+        this.tracking_summary = tracking_summary;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUrl_type() {
+        return url_type;
+    }
+
+    public void setUrl_type(String url_type) {
+        this.url_type = url_type;
+    }
+
+    public String getWebstore_last_updated() {
+        return webstore_last_updated;
+    }
+
+    public void setWebstore_last_updated(String webstore_last_updated) {
+        this.webstore_last_updated = webstore_last_updated;
+    }
+
+    public String getWebstore_url() {
+        return webstore_url;
+    }
+
+    public void setWebstore_url(String webstore_url) {
+        this.webstore_url = webstore_url;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((cache_last_updated == null) ? 0 : cache_last_updated.hashCode());
+        result = prime * result + ((cache_url == null) ? 0 : cache_url.hashCode());
+        result = prime * result + ((created == null) ? 0 : created.hashCode());
+        result = prime * result + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((format == null) ? 0 : format.hashCode());
+        result = prime * result + ((hash == null) ? 0 : hash.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((last_modified == null) ? 0 : last_modified.hashCode());
+        result = prime * result + ((mimetype == null) ? 0 : mimetype.hashCode());
+        result = prime * result + ((mimetype_inner == null) ? 0 : mimetype_inner.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((package_id == null) ? 0 : package_id.hashCode());
+        result = prime * result + (int) (position ^ (position >>> 32));
+        result = prime * result + ((resource_group_id == null) ? 0 : resource_group_id.hashCode());
+        result = prime * result + ((resource_type == null) ? 0 : resource_type.hashCode());
+        result = prime * result + ((revision_id == null) ? 0 : revision_id.hashCode());
+        result = prime * result + ((revision_timestamp == null) ? 0 : revision_timestamp.hashCode());
+        result = prime * result + (int) (size ^ (size >>> 32));
+        result = prime * result + ((state == null) ? 0 : state.hashCode());
+        result = prime * result + ((tracking_summary == null) ? 0 : tracking_summary.hashCode());
+        result = prime * result + ((url == null) ? 0 : url.hashCode());
+        result = prime * result + ((url_type == null) ? 0 : url_type.hashCode());
+        result = prime * result + ((webstore_last_updated == null) ? 0 : webstore_last_updated.hashCode());
+        result = prime * result + ((webstore_url == null) ? 0 : webstore_url.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Resource other = (Resource) obj;
+        if (cache_last_updated == null) {
+            if (other.cache_last_updated != null)
+                return false;
+        } else if (!cache_last_updated.equals(other.cache_last_updated))
+            return false;
+        if (cache_url == null) {
+            if (other.cache_url != null)
+                return false;
+        } else if (!cache_url.equals(other.cache_url))
+            return false;
+        if (created == null) {
+            if (other.created != null)
+                return false;
+        } else if (!created.equals(other.created))
+            return false;
+        if (description == null) {
+            if (other.description != null)
+                return false;
+        } else if (!description.equals(other.description))
+            return false;
+        if (format == null) {
+            if (other.format != null)
+                return false;
+        } else if (!format.equals(other.format))
+            return false;
+        if (hash == null) {
+            if (other.hash != null)
+                return false;
+        } else if (!hash.equals(other.hash))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (last_modified == null) {
+            if (other.last_modified != null)
+                return false;
+        } else if (!last_modified.equals(other.last_modified))
+            return false;
+        if (mimetype == null) {
+            if (other.mimetype != null)
+                return false;
+        } else if (!mimetype.equals(other.mimetype))
+            return false;
+        if (mimetype_inner == null) {
+            if (other.mimetype_inner != null)
+                return false;
+        } else if (!mimetype_inner.equals(other.mimetype_inner))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (package_id == null) {
+            if (other.package_id != null)
+                return false;
+        } else if (!package_id.equals(other.package_id))
+            return false;
+        if (position != other.position)
+            return false;
+        if (resource_group_id == null) {
+            if (other.resource_group_id != null)
+                return false;
+        } else if (!resource_group_id.equals(other.resource_group_id))
+            return false;
+        if (resource_type == null) {
+            if (other.resource_type != null)
+                return false;
+        } else if (!resource_type.equals(other.resource_type))
+            return false;
+        if (revision_id == null) {
+            if (other.revision_id != null)
+                return false;
+        } else if (!revision_id.equals(other.revision_id))
+            return false;
+        if (revision_timestamp == null) {
+            if (other.revision_timestamp != null)
+                return false;
+        } else if (!revision_timestamp.equals(other.revision_timestamp))
+            return false;
+        if (size != other.size)
+            return false;
+        if (state == null) {
+            if (other.state != null)
+                return false;
+        } else if (!state.equals(other.state))
+            return false;
+        if (tracking_summary == null) {
+            if (other.tracking_summary != null)
+                return false;
+        } else if (!tracking_summary.equals(other.tracking_summary))
+            return false;
+        if (url == null) {
+            if (other.url != null)
+                return false;
+        } else if (!url.equals(other.url))
+            return false;
+        if (url_type == null) {
+            if (other.url_type != null)
+                return false;
+        } else if (!url_type.equals(other.url_type))
+            return false;
+        if (webstore_last_updated == null) {
+            if (other.webstore_last_updated != null)
+                return false;
+        } else if (!webstore_last_updated.equals(other.webstore_last_updated))
+            return false;
+        if (webstore_url == null) {
+            if (other.webstore_url != null)
+                return false;
+        } else if (!webstore_url.equals(other.webstore_url))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Resource [cache_last_updated=");
+        builder.append(cache_last_updated);
+        builder.append(", cache_url=");
+        builder.append(cache_url);
+        builder.append(", created=");
+        builder.append(created);
+        builder.append(", description=");
+        builder.append(description);
+        builder.append(", format=");
+        builder.append(format);
+        builder.append(", hash=");
+        builder.append(hash);
+        builder.append(", id=");
+        builder.append(id);
+        builder.append(", last_modified=");
+        builder.append(last_modified);
+        builder.append(", mimetype=");
+        builder.append(mimetype);
+        builder.append(", mimetype_inner=");
+        builder.append(mimetype_inner);
+        builder.append(", name=");
+        builder.append(name);
+        builder.append(", package_id=");
+        builder.append(package_id);
+        builder.append(", position=");
+        builder.append(position);
+        builder.append(", resource_group_id=");
+        builder.append(resource_group_id);
+        builder.append(", resource_type=");
+        builder.append(resource_type);
+        builder.append(", revision_id=");
+        builder.append(revision_id);
+        builder.append(", revision_timestamp=");
+        builder.append(revision_timestamp);
+        builder.append(", size=");
+        builder.append(size);
+        builder.append(", state=");
+        builder.append(state);
+        builder.append(", tracking_summary=");
+        builder.append(tracking_summary);
+        builder.append(", url=");
+        builder.append(url);
+        builder.append(", url_type=");
+        builder.append(url_type);
+        builder.append(", webstore_last_updated=");
+        builder.append(webstore_last_updated);
+        builder.append(", webstore_url=");
+        builder.append(webstore_url);
+        builder.append("]");
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/org/aksw/gerbil/datasets/datahub/model/Tag.java
+++ b/src/main/java/org/aksw/gerbil/datasets/datahub/model/Tag.java
@@ -1,0 +1,161 @@
+package org.aksw.gerbil.datasets.datahub.model;
+
+import java.util.Date;
+
+/**
+ * Represents a tag
+ * 
+ * @author Ross Jones <ross.jones@okfn.org>
+ * @version 1.7
+ * @since 2012-05-01
+ */
+public class Tag {
+
+    private String display_name;
+
+    private String id;
+
+    private String name;
+
+    private Date revision_timestamp;
+
+    private String state;
+
+    private String vocabulary_id;
+
+    public Tag() {
+    }
+
+    public Tag(String display_name, String id, String name, Date revision_timestamp, String state, String vocabulary_id) {
+        super();
+        this.display_name = display_name;
+        this.id = id;
+        this.name = name;
+        this.revision_timestamp = revision_timestamp;
+        this.state = state;
+        this.vocabulary_id = vocabulary_id;
+    }
+
+    public String getDisplay_name() {
+        return display_name;
+    }
+
+    public void setDisplay_name(String display_name) {
+        this.display_name = display_name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Date getRevision_timestamp() {
+        return revision_timestamp;
+    }
+
+    public void setRevision_timestamp(Date revision_timestamp) {
+        this.revision_timestamp = revision_timestamp;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getVocabulary_id() {
+        return vocabulary_id;
+    }
+
+    public void setVocabulary_id(String vocabulary_id) {
+        this.vocabulary_id = vocabulary_id;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((display_name == null) ? 0 : display_name.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((revision_timestamp == null) ? 0 : revision_timestamp.hashCode());
+        result = prime * result + ((state == null) ? 0 : state.hashCode());
+        result = prime * result + ((vocabulary_id == null) ? 0 : vocabulary_id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Tag other = (Tag) obj;
+        if (display_name == null) {
+            if (other.display_name != null)
+                return false;
+        } else if (!display_name.equals(other.display_name))
+            return false;
+        if (id == null) {
+            if (other.id != null)
+                return false;
+        } else if (!id.equals(other.id))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (revision_timestamp == null) {
+            if (other.revision_timestamp != null)
+                return false;
+        } else if (!revision_timestamp.equals(other.revision_timestamp))
+            return false;
+        if (state == null) {
+            if (other.state != null)
+                return false;
+        } else if (!state.equals(other.state))
+            return false;
+        if (vocabulary_id == null) {
+            if (other.vocabulary_id != null)
+                return false;
+        } else if (!vocabulary_id.equals(other.vocabulary_id))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Tag [display_name=");
+        builder.append(display_name);
+        builder.append(", id=");
+        builder.append(id);
+        builder.append(", name=");
+        builder.append(name);
+        builder.append(", revision_timestamp=");
+        builder.append(revision_timestamp);
+        builder.append(", state=");
+        builder.append(state);
+        builder.append(", vocabulary_id=");
+        builder.append(vocabulary_id);
+        builder.append("]");
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/org/aksw/gerbil/utils/DatasetName2ExperimentTypeMapping.java
+++ b/src/main/java/org/aksw/gerbil/utils/DatasetName2ExperimentTypeMapping.java
@@ -12,6 +12,7 @@ import org.aksw.gerbil.datasets.CMNSDatasetConfig;
 import org.aksw.gerbil.datasets.IITBDatasetConfig;
 import org.aksw.gerbil.datasets.KnownNIFFileDatasetConfig.NIFDatasets;
 import org.aksw.gerbil.datasets.MSNBCDatasetConfig;
+import org.aksw.gerbil.datasets.datahub.DatahubNIFLoader;
 import org.aksw.gerbil.datatypes.ExperimentType;
 
 public class DatasetName2ExperimentTypeMapping {
@@ -37,6 +38,12 @@ public class DatasetName2ExperimentTypeMapping {
             NIFDatasets nifDatasets[] = NIFDatasets.values();
             for (int i = 0; i < nifDatasets.length; ++i) {
                 mapping.put(nifDatasets[i].getDatasetName(), ExperimentType.Sa2W);
+            }
+
+            // put Datahub data in it too
+            DatahubNIFLoader datahub = new DatahubNIFLoader();
+            for (String s : datahub.getDataSets().keySet()) {
+                mapping.put(s, ExperimentType.Sa2W);
             }
 
             instance = new DatasetName2ExperimentTypeMapping(mapping);

--- a/src/main/java/org/aksw/gerbil/utils/Name2DatasetMapping.java
+++ b/src/main/java/org/aksw/gerbil/utils/Name2DatasetMapping.java
@@ -1,5 +1,7 @@
 package org.aksw.gerbil.utils;
 
+import java.util.Map.Entry;
+
 import it.acubelab.batframework.systemPlugins.DBPediaApi;
 
 import org.aksw.gerbil.datasets.ACE2004DatasetConfig;
@@ -7,10 +9,12 @@ import org.aksw.gerbil.datasets.AIDACoNLLDatasetConfig;
 import org.aksw.gerbil.datasets.AIDACoNLLDatasetConfig.AIDACoNLLChunk;
 import org.aksw.gerbil.datasets.AQUAINTDatasetConfiguration;
 import org.aksw.gerbil.datasets.CMNSDatasetConfig;
+import org.aksw.gerbil.datasets.DatahubNIFConfig;
 import org.aksw.gerbil.datasets.DatasetConfiguration;
 import org.aksw.gerbil.datasets.IITBDatasetConfig;
 import org.aksw.gerbil.datasets.KnownNIFFileDatasetConfig;
 import org.aksw.gerbil.datasets.KnownNIFFileDatasetConfig.NIFDatasets;
+import org.aksw.gerbil.datasets.datahub.DatahubNIFLoader;
 import org.aksw.gerbil.datasets.MSNBCDatasetConfig;
 
 public class Name2DatasetMapping {
@@ -61,6 +65,15 @@ public class Name2DatasetMapping {
             if (nifDatasets[i].getDatasetName().equals(name)) {
                 return new KnownNIFFileDatasetConfig(SingletonWikipediaApi.getInstance(), new DBPediaApi(),
                         nifDatasets[i]);
+            }
+        }
+
+        DatahubNIFLoader dh = new DatahubNIFLoader();
+        for (Entry<String, String> d : dh.getDataSets().entrySet()) {
+            if (d.getKey().equals(name)) {
+                // FIXME - last boolean is cachable. oculd it really be cached?
+                return new DatahubNIFConfig(SingletonWikipediaApi.getInstance(), new DBPediaApi(), d.getKey(),
+                        d.getValue(), true);
             }
         }
 

--- a/src/main/java/org/aksw/gerbil/web/MainController.java
+++ b/src/main/java/org/aksw/gerbil/web/MainController.java
@@ -181,7 +181,9 @@ public class MainController {
     @RequestMapping("/datasets")
     public @ResponseBody
     Set<String> datasets(@RequestParam(value = "experimentType") String experimentType) {
-        return DatasetName2ExperimentTypeMapping.getDatasetsForExperimentType(ExperimentType.valueOf(experimentType));
+        //TODO - add datahub datasets
+        Set<String> datasets = DatasetName2ExperimentTypeMapping.getDatasetsForExperimentType(ExperimentType.valueOf(experimentType));
+        return datasets;
     }
 
 }

--- a/src/main/java/org/aksw/gerbil/web/config/DatabaseConfig.java
+++ b/src/main/java/org/aksw/gerbil/web/config/DatabaseConfig.java
@@ -3,7 +3,6 @@ package org.aksw.gerbil.web.config;
 import org.aksw.gerbil.database.ExperimentDAO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/org/aksw/gerbil/web/config/WebMvcConfig.java
+++ b/src/main/java/org/aksw/gerbil/web/config/WebMvcConfig.java
@@ -1,6 +1,5 @@
 package org.aksw.gerbil.web.config;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -14,25 +13,27 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
 @Configuration
 @EnableWebMvc
-@ComponentScan(basePackages="org.aksw.gerbil.web")
-public class WebMvcConfig extends WebMvcConfigurerAdapter{
-	
-	private static final transient Logger logger = LoggerFactory.getLogger(WebMvcConfig.class);
-	/**
-	 * @return the view resolver
-	 */
-	@Bean
-	public ViewResolver viewResolver() {
-		logger.debug("setting up view resolver");
-		InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
-		viewResolver.setPrefix("/WEB-INF/views/");
-		viewResolver.setSuffix(".jsp");
-		return viewResolver;
-	}
-	
-	@Override
-	  public void addResourceHandlers(ResourceHandlerRegistry registry) {
-	    registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
-	    registry.addResourceHandler("/webResources/**").addResourceLocations("classpath:webResources/");
-	  }
+@ComponentScan(basePackages = { "org.aksw.gerbil.web", "org.aksw.gerbil.datasets.datahub" })
+public class WebMvcConfig extends WebMvcConfigurerAdapter {
+
+    private static final transient Logger logger = LoggerFactory.getLogger(WebMvcConfig.class);
+
+    /**
+     * @return the view resolver
+     */
+    @Bean
+    public ViewResolver viewResolver() {
+        logger.debug("setting up view resolver");
+        InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
+        viewResolver.setPrefix("/WEB-INF/views/");
+        viewResolver.setSuffix(".jsp");
+        return viewResolver;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+        registry.addResourceHandler("/webResources/**").addResourceLocations("classpath:webResources/");
+    }
+
 }

--- a/src/main/resources/gerbil.properties
+++ b/src/main/resources/gerbil.properties
@@ -76,3 +76,5 @@ org.aksw.gerbil.datasets.MSNBCDatasetConfig.AnnotationsFolder=${org.aksw.gerbil.
 org.aksw.gerbil.datasets.KnownNIFFileDatasetConfig.N3_NEWS_100=${org.aksw.gerbil.DataPath}/datasets/N3/News-100.ttl
 org.aksw.gerbil.datasets.KnownNIFFileDatasetConfig.N3_REUTERS_128=${org.aksw.gerbil.DataPath}/datasets/N3/Reuters-128.ttl
 org.aksw.gerbil.datasets.KnownNIFFileDatasetConfig.N3_RSS_500=${org.aksw.gerbil.DataPath}/datasets/N3/RSS-500.ttl
+
+org.aksw.gerbil.datasets.Datahub=${org.aksw.gerbil.DataPath}/datasets/datahub/

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,14 @@
 # Direct log messages to stdout
-log4j.rootLogger=WARN,stdout
+log4j.rootLogger=DEBUG,stdout, file
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
+
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.file=gerbil.log
+log4j.appender.file.Append=true
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.conversionPattern=%d %p [%c] - <%m>%n
 
 log4j.category.org.aksw.palmetto=INFO

--- a/start.sh
+++ b/start.sh
@@ -18,4 +18,4 @@ if [ ! -f "$file" ]; then
     fi
 fi
 
-mvn clean tomcat:run -Dmaven.tomcat.port=1234 &
+mvn clean tomcat:run -Dmaven.tomcat.port=1234


### PR DESCRIPTION
The connection to datahub is established.
Datasets with the following properties will be available in gerbil:
- nif tagged
- end with .ttl
- ends NOT with dataid.ttl
- less than 20Mb

Currently the Datahub loader is no static instance.
The first time the website will be loaded the dataset names and
path to the files will be loaded.
Every time the experiment starts the information would be loaded.
This should be fixed if the 'springify' (ref #22) is done.

Removed the background loading of the tomcat (in start.sh the &).
So the tomcat is easier to stop.

Add a file logging. All log messages will now be add to the file
gerbil.log (should be set to .gitignore)

Currently there is a bug in the filepath where the nif datasets should
be written to. The path would not load properly from the
GerbilConfiguration and I did not found the problem. I will open an
issue for that.

fix #10
