### PR TITLE
Handling of empty datasets

### DIFF
--- a/src/main/java/org/aksw/gerbil/datatypes/ErrorTypes.java
+++ b/src/main/java/org/aksw/gerbil/datatypes/ErrorTypes.java
@@ -35,6 +35,10 @@ public enum ErrorTypes {
      * The dataset couldn't be loaded.
      */
     DATASET_LOADING_ERROR(-104, "The dataset couldn't be loaded."),
+    /**
+     * The dataset appears not .
+     */
+    DATASET_EMPTY_ERROR(-110, "The dataset appeared to be empty."),
 
     /**
      * The annotator does not support the experiment type.

--- a/src/main/java/org/aksw/gerbil/execute/ExperimentTask.java
+++ b/src/main/java/org/aksw/gerbil/execute/ExperimentTask.java
@@ -106,6 +106,11 @@ public class ExperimentTask implements Task {
 				throw new GerbilException("dataset=\"" + configuration.datasetConfig.getName() + "\" experimentType=\""
 						+ configuration.type.name() + "\".", ErrorTypes.DATASET_DOES_NOT_SUPPORT_EXPERIMENT);
 			}
+			// Check the dataset
+			if (dataset.size() == 0) {
+			    throw new GerbilException("dataset=\"" + configuration.datasetConfig.getName() + "\" experimentType=\""
+                        + configuration.type.name() + "\".", ErrorTypes.DATASET_EMPTY_ERROR);
+			}
 
 			// Create annotator
 			annotator = (Annotator) configuration.annotatorConfig.getAnnotator(configuration.type);

--- a/src/test/java/org/aksw/gerbil/execute/AbstractExperimentTaskTest.java
+++ b/src/test/java/org/aksw/gerbil/execute/AbstractExperimentTaskTest.java
@@ -105,7 +105,7 @@ public abstract class AbstractExperimentTaskTest {
 
     }
 
-    protected static class F1MeasureTestingObserver extends ExceptionExpectingTestTaskObserver {
+    protected static class F1MeasureTestingObserver extends StatusCheckingTestTaskObserver {
 
         public static int MACRO_PREC_INDEX = 0;
         public static int MACRO_REC_INDEX = 1;
@@ -141,14 +141,23 @@ public abstract class AbstractExperimentTaskTest {
             Assert.assertEquals(errorMsg, expectedResults[ERROR_COUNT_INDEX], (Integer) resMap.get("Error Count").getResValue(), DELTA);
         }
     }
-    
-    public static class ExceptionExpectingTestTaskObserver extends AbstractJUnitTestTaskObserver {
+
+    /**
+     * {@link AbstractJUnitTestTaskObserver} instance which checks a the given task
+     * for its status after its termination. It compares the tasks status with the
+     * given expected status and throws an {@link AssertionError} if they
+     * do not match.
+     * 
+     * @author Michael R&ouml;der (michael.roeder@uni-paderborn.de)
+     *
+     */
+    public static class StatusCheckingTestTaskObserver extends AbstractJUnitTestTaskObserver {
         
         protected int experimentTaskId;
         protected SimpleLoggingResultStoringDAO4Debugging experimentDAO;
         protected int expectedStatus;
 
-        public ExceptionExpectingTestTaskObserver(AbstractExperimentTaskTest testInstance, 
+        public StatusCheckingTestTaskObserver(AbstractExperimentTaskTest testInstance, 
                 int experimentTaskId,
                 SimpleLoggingResultStoringDAO4Debugging experimentDAO, int expectedStatus) {
             super(testInstance);
@@ -158,15 +167,9 @@ public abstract class AbstractExperimentTaskTest {
         }
         
         @Override
-        public void reportTaskThrowedException(Task task, Throwable t) {
-            super.reportTaskThrowedException(task, t);
-        }
-
-        @Override
         protected void testTaskResults(Task task) {
             Assert.assertEquals("The experiment has not the expected status.", 
                     expectedStatus , experimentDAO.getExperimentState(experimentTaskId));
         }
-        
     }
 }

--- a/src/test/java/org/aksw/gerbil/execute/EmptyDatasetTest.java
+++ b/src/test/java/org/aksw/gerbil/execute/EmptyDatasetTest.java
@@ -26,6 +26,7 @@ import org.aksw.gerbil.datatypes.ExperimentTaskConfiguration;
 import org.aksw.gerbil.datatypes.ExperimentType;
 import org.aksw.gerbil.evaluate.EvaluatorFactory;
 import org.aksw.gerbil.matching.Matching;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -42,13 +43,21 @@ public class EmptyDatasetTest extends AbstractExperimentTaskTest {
     @SuppressWarnings("unchecked")
     @Test
     public void test() {
+        try {
         int experimentTaskId = 1;
         SimpleLoggingResultStoringDAO4Debugging experimentDAO = new SimpleLoggingResultStoringDAO4Debugging();
         ExperimentTaskConfiguration configuration = new ExperimentTaskConfiguration(
                 new TestAnnotatorConfiguration(Collections.EMPTY_LIST, EXPERIMENT_TYPE),
                 new InstanceListBasedDataset(Collections.EMPTY_LIST, EXPERIMENT_TYPE), EXPERIMENT_TYPE, MATCHING);
         runTest(experimentTaskId, experimentDAO, new EvaluatorFactory(), configuration,
-                new ExceptionExpectingTestTaskObserver(this, experimentTaskId, experimentDAO,
+                new StatusCheckingTestTaskObserver(this, experimentTaskId, experimentDAO,
                         ErrorTypes.DATASET_EMPTY_ERROR.getErrorCode()));
+        } catch(AssertionError e) {
+            throw e;
+        } catch(Exception e) {
+            // not necessary but it makes Codacy happy
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
     }
 }

--- a/src/test/java/org/aksw/gerbil/execute/EmptyDatasetTest.java
+++ b/src/test/java/org/aksw/gerbil/execute/EmptyDatasetTest.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of General Entity Annotator Benchmark.
+ *
+ * General Entity Annotator Benchmark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * General Entity Annotator Benchmark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with General Entity Annotator Benchmark.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aksw.gerbil.execute;
+
+import java.util.Collections;
+
+import org.aksw.gerbil.annotator.TestAnnotatorConfiguration;
+import org.aksw.gerbil.database.SimpleLoggingResultStoringDAO4Debugging;
+import org.aksw.gerbil.dataset.InstanceListBasedDataset;
+import org.aksw.gerbil.datatypes.ErrorTypes;
+import org.aksw.gerbil.datatypes.ExperimentTaskConfiguration;
+import org.aksw.gerbil.datatypes.ExperimentType;
+import org.aksw.gerbil.evaluate.EvaluatorFactory;
+import org.aksw.gerbil.matching.Matching;
+import org.junit.Test;
+
+/**
+ * This class tests the execution of an experiment with an empty dataset.
+ * 
+ * @author Michael R&ouml;der (mroeder@uni-paderborn.de)
+ * 
+ */
+public class EmptyDatasetTest extends AbstractExperimentTaskTest {
+
+    private static final ExperimentType EXPERIMENT_TYPE = ExperimentType.A2KB;
+    private static final Matching MATCHING = Matching.WEAK_ANNOTATION_MATCH;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test() {
+        int experimentTaskId = 1;
+        SimpleLoggingResultStoringDAO4Debugging experimentDAO = new SimpleLoggingResultStoringDAO4Debugging();
+        ExperimentTaskConfiguration configuration = new ExperimentTaskConfiguration(
+                new TestAnnotatorConfiguration(Collections.EMPTY_LIST, EXPERIMENT_TYPE),
+                new InstanceListBasedDataset(Collections.EMPTY_LIST, EXPERIMENT_TYPE), EXPERIMENT_TYPE, MATCHING);
+        runTest(experimentTaskId, experimentDAO, new EvaluatorFactory(), configuration,
+                new ExceptionExpectingTestTaskObserver(this, experimentTaskId, experimentDAO,
+                        ErrorTypes.DATASET_EMPTY_ERROR.getErrorCode()));
+    }
+}


### PR DESCRIPTION
Added a new test case and an ErrorType for cases in which the dataset is empty. Added the handling of this issue to the ExpeirmentTask. Fixes #295.