### PR TITLE
dockerized

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,7 +1,7 @@
-# #!/bin/bash
+#!/bin/bash
 
 export PROJECT="gerbil"
-VERSION=`mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
+VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
 
 # build the docker container
 docker build --no-cache -t philippkuntschik/$PROJECT .


### PR DESCRIPTION
Dear all,

I created a initial version of docker related scripts that enable our organization to comfortably deploy gerbil on our local servers. Included are:

* `docker_build.sh`, a script to build the docker container on localhost. I have to `-DskipTests` since the current master does not pass all unit-tests (at least immediately after a git pull).
* `run-gerbil.sh` a script that downloads all dependencies and starts the service subsequently. This file contains a `export gerbil_home=~/gerbil/` statement that should be adapted on the target computer.

The scripts represent a quick way to build a docker container. A more elegant solution would a) introduce similar statements to the travis-ci scripts, or b) adapt the Dockerfile to use multi-staging (see: https://blog.docker.com/2017/07/multi-stage-builds/).

Please feel free to adapt everything to your desire, especially the docker-repository. For now, the docker image is available at https://cloud.docker.com/u/philippkuntschik/repository/docker/philippkuntschik/gerbil

cheers, 
phil