### PR TITLE
Enable OpenTapioca for A2KB

### DIFF
--- a/src/main/properties/annotators.properties
+++ b/src/main/properties/annotators.properties
@@ -177,7 +177,7 @@ org.aksw.gerbil.annotators.definition.NERFGUN.constructorArgs=${org.aksw.gerbil.
 ### OpenTapioca
 org.aksw.gerbil.annotators.OpenTapioca.serviceUrl=https://opentapioca.org/api/nif
 org.aksw.gerbil.annotators.definition.OpenTapioca.name=OpenTapioca
-org.aksw.gerbil.annotators.definition.OpenTapioca.experimentType=D2KB
+org.aksw.gerbil.annotators.definition.OpenTapioca.experimentType=A2KB
 org.aksw.gerbil.annotators.definition.OpenTapioca.cacheable=true
 org.aksw.gerbil.annotators.definition.OpenTapioca.class=org.aksw.gerbil.annotator.impl.nif.NIFBasedAnnotatorWebservice
 org.aksw.gerbil.annotators.definition.OpenTapioca.constructorArgs=${org.aksw.gerbil.annotators.OpenTapioca.serviceUrl}


### PR DESCRIPTION
OpenTapioca does not require pre-annotated texts so it should be possible to use it for A2KB tasks too.