### PR TITLE
Replaced OpenHashMap with normal Maps where stability is necessary

### DIFF
--- a/src/main/java/org/aksw/gerbil/http/HttpManagement.java
+++ b/src/main/java/org/aksw/gerbil/http/HttpManagement.java
@@ -61,7 +61,28 @@ public class HttpManagement {
     private static final String USER_AGENT_STRING = "GERBIL/" + GerbilConfiguration.getGerbilVersion()
             + " (http://aksw.org/Projects/GERBIL.html)";
 
+    /**
+     * Singleton instance.
+     */
     private static HttpManagement instance;
+
+    /**
+     * The interrupting observer used to interrupt requests that take too long.
+     */
+    protected InterruptingObserver interruptingObserver;
+    /**
+     * The HTTP client used for all HTTP communication.
+     */
+    protected CloseableHttpClient client;
+    /**
+     * The usage agent string of this program.
+     */
+    protected String userAgent;
+    /**
+     * The map of domains that could block this client and the last time at which
+     * they have been accessed.
+     */
+    protected Map<String, Long> blockingDomainTimestampMapping = new HashMap<>();
 
     public synchronized static HttpManagement getInstance() {
         if (instance == null) {
@@ -93,14 +114,9 @@ public class HttpManagement {
         return instance;
     }
 
-    protected InterruptingObserver interruptingObserver;
-    protected CloseableHttpClient client;
-    protected String userAgent;
-    protected Map<String, Long> blockingDomainTimestampMapping = new HashMap<>();
-
     protected HttpManagement(InterruptingObserver interruptingObserver, String userAgent) {
         this.interruptingObserver = interruptingObserver;
-        this.client = generateHttpClientBuilder().build();
+        this.client = generateHttpClientBuilder().setUserAgent(userAgent).build();
     }
 
     public void reportStart(HttpRequestEmitter emitter, HttpUriRequest request) {

--- a/src/main/java/org/aksw/gerbil/http/HttpManagement.java
+++ b/src/main/java/org/aksw/gerbil/http/HttpManagement.java
@@ -116,7 +116,8 @@ public class HttpManagement {
 
     protected HttpManagement(InterruptingObserver interruptingObserver, String userAgent) {
         this.interruptingObserver = interruptingObserver;
-        this.client = generateHttpClientBuilder().setUserAgent(userAgent).build();
+        this.userAgent = userAgent;
+        this.client = generateHttpClientBuilder().build();
     }
 
     public void reportStart(HttpRequestEmitter emitter, HttpUriRequest request) {

--- a/src/main/java/org/aksw/gerbil/http/InterruptingObserver.java
+++ b/src/main/java/org/aksw/gerbil/http/InterruptingObserver.java
@@ -17,6 +17,7 @@
 package org.aksw.gerbil.http;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -54,14 +55,16 @@ public class InterruptingObserver implements Runnable {
             long waitingTime;
             long currentTime = System.currentTimeMillis();
             ObservedHttpRequest observedRequest;
-            for (Entry<ObservedHttpRequest, Long> e : observedRequests.entrySet()) {
-                waitingTime = currentTime - e.getValue();
+            Iterator<Entry<ObservedHttpRequest, Long>> iterator = observedRequests.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Entry<ObservedHttpRequest, Long> entry = iterator.next();
+                waitingTime = currentTime - entry.getValue();
                 if (waitingTime > maxWaitingTime) {
-                    observedRequest = e.getKey();
+                    observedRequest = entry.getKey();
                     if (observedRequest.request.isAborted()) {
                         LOGGER.warn(
                                 "Observing an HTTP request that is already aborted. This could be mean that the HTTP management does not have been informed about the termination of a request.");
-                        observedRequests.remove(observedRequest);
+                        iterator.remove();
                     } else {
                         LOGGER.info("The HTTP request emitter \"{}\" already runs for {} ms. Trying to interrupt it.",
                                 observedRequest.emitter.getName(), waitingTime);

--- a/src/main/java/org/aksw/gerbil/http/InterruptingObserver.java
+++ b/src/main/java/org/aksw/gerbil/http/InterruptingObserver.java
@@ -69,8 +69,6 @@ public class InterruptingObserver implements Runnable {
                     }
                 }
             }
-        } finally {
-            observedMappingMutex.release();
         }
     }
 

--- a/src/main/java/org/aksw/gerbil/http/InterruptingObserver.java
+++ b/src/main/java/org/aksw/gerbil/http/InterruptingObserver.java
@@ -16,13 +16,13 @@
  */
 package org.aksw.gerbil.http;
 
-import java.util.concurrent.Semaphore;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.http.client.methods.HttpUriRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.carrotsearch.hppc.ObjectLongOpenHashMap;
 
 public class InterruptingObserver implements Runnable {
 
@@ -30,8 +30,7 @@ public class InterruptingObserver implements Runnable {
 
     private long maxWaitingTime;
     private long checkInterval;
-    private final ObjectLongOpenHashMap<ObservedHttpRequest> observedRequests = new ObjectLongOpenHashMap<ObservedHttpRequest>();
-    private final Semaphore observedMappingMutex = new Semaphore(1);
+    private final Map<ObservedHttpRequest, Long> observedRequests = new HashMap<>();
 
     public InterruptingObserver(long maxWaitingTime, long checkInterval) {
         this.maxWaitingTime = maxWaitingTime;
@@ -51,25 +50,19 @@ public class InterruptingObserver implements Runnable {
     }
 
     private void checkAnnotators() {
-        try {
-            observedMappingMutex.acquire();
-        } catch (InterruptedException e) {
-            LOGGER.error("Interrupted while waiting for mutex. Aborting.");
-        }
-
-        long waitingTime;
-        long currentTime = System.currentTimeMillis();
-        ObservedHttpRequest observedRequest;
-        for (int i = 0; i < observedRequests.allocated.length; ++i) {
-            if (observedRequests.allocated[i]) {
-                waitingTime = currentTime - observedRequests.values[i];
+        synchronized (observedRequests) {
+            long waitingTime;
+            long currentTime = System.currentTimeMillis();
+            ObservedHttpRequest observedRequest;
+            for (Entry<ObservedHttpRequest, Long> e : observedRequests.entrySet()) {
+                waitingTime = currentTime - e.getValue();
                 if (waitingTime > maxWaitingTime) {
-                    observedRequest = ((ObservedHttpRequest) ((Object[]) observedRequests.keys)[i]);
+                    observedRequest = e.getKey();
                     LOGGER.info("The HTTP request emitter \"{}\" already runs for {} ms. Trying to interrupt it.",
                             observedRequest.emitter.getName(), waitingTime);
                     try {
                         observedRequest.emitter.interrupt(observedRequest.request);
-                    } catch (UnsupportedOperationException e) {
+                    } catch (UnsupportedOperationException ex) {
                         LOGGER.error("Couldn't interrupt request of HTTP request emitter \""
                                 + observedRequest.emitter.getName() + "\" that is already running for " + waitingTime
                                 + " ms.");
@@ -77,38 +70,29 @@ public class InterruptingObserver implements Runnable {
                 }
             }
         }
-        observedMappingMutex.release();
     }
 
     public void reportStart(HttpRequestEmitter emitter, HttpUriRequest request) {
         ObservedHttpRequest observedRequest = new ObservedHttpRequest(request, emitter);
-        try {
-            observedMappingMutex.acquire();
-        } catch (InterruptedException e) {
-            LOGGER.error("Interrupted while waiting for mutex. Aborting.");
+        synchronized (observedRequests) {
+            if (observedRequests.containsKey(observedRequest)) {
+                LOGGER.error("There already is an observed request equal to this new one (" + observedRequest.toString()
+                        + "). Note that this is a fatal error and the old request will be overwritten.");
+            }
+            observedRequests.put(observedRequest, System.currentTimeMillis());
         }
-        if (observedRequests.containsKey(observedRequest)) {
-            LOGGER.error("There already is an observed request equal to this new one (" + observedRequest.toString()
-                    + "). Note that this is a fatal error and the old request will be overwritten.");
-        }
-        observedRequests.put(observedRequest, System.currentTimeMillis());
-        observedMappingMutex.release();
     }
 
     public void reportEnd(HttpRequestEmitter emitter, HttpUriRequest request) {
         ObservedHttpRequest observedRequest = new ObservedHttpRequest(request, emitter);
-        try {
-            observedMappingMutex.acquire();
-        } catch (InterruptedException e) {
-            LOGGER.error("Interrupted while waiting for mutex. Aborting.");
+        synchronized (observedRequests) {
+            if (observedRequests.containsKey(observedRequest)) {
+                observedRequests.remove(observedRequest);
+            } else {
+                LOGGER.error("Tried to remove an observed request that is not existing (" + observedRequest.toString()
+                        + "). This is a fatal error.");
+            }
         }
-        if (observedRequests.containsKey(observedRequest)) {
-            observedRequests.remove(observedRequest);
-        } else {
-            LOGGER.error("Tried to remove an observed request that is not existing (" + observedRequest.toString()
-                    + "). This is a fatal error.");
-        }
-        observedMappingMutex.release();
     }
 
     public long getMaxWaitingTime() {


### PR DESCRIPTION
Replaced the usage of OpenHashMap in the HTTP management and observer classes by java.util Maps to ensure stability. In addition, Semaphores have been replaced by synchronized blocks to increase stability. Fixed #177.