### PR TITLE
Fix WAT Disambiguation parameter

### DIFF
--- a/src/main/java/org/aksw/gerbil/annotator/impl/wat/WATAnnotator.java
+++ b/src/main/java/org/aksw/gerbil/annotator/impl/wat/WATAnnotator.java
@@ -55,7 +55,7 @@ public class WATAnnotator extends AbstractHttpBasedAnnotator implements A2KBAnno
     private static final String WAT_CONFIG_FILE_PROPERTY_ENDPOINT = "org.aksw.gerbil.annotators.wat.disambiguateUrl";
     private static final String WAT_CONFIG_FILE_PROPERTY_PARAMETERS = "org.aksw.gerbil.annotators.wat.annotateUrl";
 
-    private static final String SPANS_REQUEST_PARAMETER_KEY = "suggested_spans";
+    private static final String SPANS_REQUEST_PARAMETER_KEY = "spans";
     private static final String TEXT_REQUEST_PARAMETER_KEY = "text";
     private static final String ENTITY_TITLE_KEY = "title";
     private static final String ENTITY_CONFIDENCE_KEY = "rho";


### PR DESCRIPTION
The WAT Disambiguation annotator (for D2KB task) uses "spans" instead of "suggested spans". This is tested locally to improve micro-F1 score by as much as 10%, which makes it comparable to SOTA methods. 

You can also find this in the official documentation: https://sobigdata.d4science.org/web/tagme/wat-api under Advanced use