### PR TITLE
Handle null explanation responses in QA polling

### DIFF
--- a/src/main/java/org/aksw/gerbil/web/ExplanationPollingJob.java
+++ b/src/main/java/org/aksw/gerbil/web/ExplanationPollingJob.java
@@ -3,6 +3,7 @@ package org.aksw.gerbil.web;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.aksw.gerbil.database.ExperimentDAO;
 import org.aksw.gerbil.database.PendingExplanationTask;
@@ -55,10 +56,13 @@ public class ExplanationPollingJob {
                         @SuppressWarnings("unchecked")
                         Map<String, String> map = (Map<String, String>) JSONValue.parse(responseBody);
 
-                        String pruneCELResult = map.getOrDefault("pruneCELResult", "");
-                        pruneCELResult = pruneCELResult.trim();
-                        String llmResult = map.getOrDefault("llmResult", "");
-                        llmResult = llmResult.trim();
+                        if (map == null) {
+                            log.warn("Received empty or invalid explanation payload for task {}", taskId);
+                            continue;
+                        }
+
+                        String pruneCELResult = Objects.toString(map.get("pruneCELResult"), "").trim();
+                        String llmResult = Objects.toString(map.get("llmResult"), "").trim();
 
                         experimentDAO.setExplanation(taskId, ExplanationService.MACHINE_READABLE_EXPLANATION_NAME,
                                 pruneCELResult);

--- a/src/main/java/org/aksw/gerbil/web/ExplanationService.java
+++ b/src/main/java/org/aksw/gerbil/web/ExplanationService.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.aksw.gerbil.evaluate.AggregatedContingencyMetricsReport;
 import org.aksw.gerbil.evaluate.EvaluationResult;
@@ -107,8 +108,8 @@ public class ExplanationService implements AutoCloseable {
             parameters.addProperty("dataset", dataset);
         }
 
-        parameters.addProperty("positive", String.join(",", positive.stream().map(String::valueOf).toList()));
-        parameters.addProperty("negative", String.join(",", negative.stream().map(String::valueOf).toList()));
+        parameters.addProperty("positive", String.join(",", positive.stream().map(String::valueOf).collect(Collectors.toList())));
+        parameters.addProperty("negative", String.join(",", negative.stream().map(String::valueOf).collect(Collectors.toList())));
         parameters.addProperty("time", 600000);
 
         HttpPost request = new HttpPost(explanationUrl);

--- a/src/main/webapp/WEB-INF/views/experiment.jsp
+++ b/src/main/webapp/WEB-INF/views/experiment.jsp
@@ -67,7 +67,7 @@
 		<c:if test="${task.numberOfSubTasks > 0}">
 			<c:set var="hasSubTasks" value="true" />
 		</c:if>
-        <c:if test="${task.explanationURL != null}">
+        <c:if test="${not empty task.explanation}">
             <c:set var="hasExplanation" value="true" />
         </c:if>
 	</c:forEach>
@@ -137,7 +137,7 @@
 					<td>${task.timestampstring}</td>
 					<td>${task.gerbilVersion}</td>
 				</tr>
-				<c:if test="${task.explanationURL != null}">
+                <c:if test="${not empty task.explanation}">
 					<tr>
 						<td>${task.annotator}</td>
 						<td>${task.dataset}</td>


### PR DESCRIPTION
Make ExplanationPollingJob null-safe for pruneCELResult / llmResult and hide empty explanation rows in the experiment UI. This prevents QA runs from crashing when the explanation service returns null results.